### PR TITLE
Bug#14 terser-webpack-plugin 충돌

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20279,9 +20279,9 @@
       }
     },
     "terser": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.3.8.tgz",
-      "integrity": "sha512-zVotuHoIfnYjtlurOouTazciEfL7V38QMAOhGqpXDEg6yT13cF4+fEP9b0rrCEQTn+tT46uxgFsTZzhygk+CzQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.4.0.tgz",
+      "integrity": "sha512-3dZunFLbCJis9TAF2VnX+VrQLctRUmt1p3W2kCsJuZE4ZgWqh//+1MZ62EanewrqKoUf4zIaDGZAvml4UDc0OQ==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -20298,17 +20298,20 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.0.3.tgz",
-      "integrity": "sha512-zFdGk8Lh9ZJGPxxPE6jwysOlATWB8GMW8HcfGULWA/nPal+3VdATflQvSBSLQJRCmYZnfFJl6vkRTiwJGNgPiQ==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-4.2.3.tgz",
+      "integrity": "sha512-jTgXh40RnvOrLQNgIkwEKnQ8rmHjHK4u+6UBEi+W+FPmvb+uo+chJXntKe7/3lW5mNysgSWD60KyesnhW8D6MQ==",
       "dev": true,
       "requires": {
-        "jest-worker": "^26.6.1",
+        "cacache": "^15.0.5",
+        "find-cache-dir": "^3.3.1",
+        "jest-worker": "^26.5.0",
         "p-limit": "^3.0.2",
         "schema-utils": "^3.0.0",
         "serialize-javascript": "^5.0.1",
         "source-map": "^0.6.1",
-        "terser": "^5.3.8"
+        "terser": "^5.3.4",
+        "webpack-sources": "^1.4.3"
       },
       "dependencies": {
         "p-limit": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "react-is": "^17.0.1",
     "react-refresh": "^0.9.0",
     "react-testing-library": "^8.0.1",
-    "terser-webpack-plugin": "^5.0.3",
+    "terser-webpack-plugin": "^4.2.3",
     "ts-loader": "^8.0.7",
     "typescript": "^4.0.5",
     "url-loader": "^4.1.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,7 +60,7 @@ module.exports = (webpackEnv) => {
       type: isEnvDevelopment ? "memory" : isEnvProduction && "filesystem",
     },
     optimization: {
-      minimize: true,
+      minimize: isEnvProduction,
       minimizer: [new TerserPlugin()],
       splitChunks: {
         chunks: "all",


### PR DESCRIPTION
## 관련 이슈

- 관련된 이슈를 모두 나열합니다.
resolved: #14

## 변경 사항

- 어제까지만 해도 빌드 과정에서 이상이 없었지만, 금일 빌드 과정에서 terser-webpack-plugin과 충돌되고 있습니다.
- terser-webpack-plugin의 버전 번호를 5.0.3에서 4.2.3으로 내린 결과, 충돌되는 문제점은 해결하였습니다.
- 추후에 다시 버전 번호를 올렸을 때 문제가 없는지 확인이 필요합니다.

## PR Point

- 리뷰어가 중점적으로 확인이 필요한 부분을 작성합니다.

## 참고 사항

- 그 외에 참고가 필요한 부분을 작성합니다.

## Check Point

- [ ] 빌드를 직접해서 올려보셨나요?
- [ ] 사용하지 않는 변수, import, 함수 등은 없나요?
- [ ] 테스트는 작성하셨나요?
- [ ] 테스트를 돌려보셨나요?
