### PR TITLE
[추가] : 버튼, 해시태그, 인풋 atoms 추가

### DIFF
--- a/src/common/Atoms/Button/button.stories.tsx
+++ b/src/common/Atoms/Button/button.stories.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { AiFillAccountBook } from "react-icons/ai";
+import { action } from "@storybook/addon-actions";
+import Button from "./index";
+
+export const butonWithoutIcon = () => {
+  return <Button text="butonWithoutIcon" onClick={action("onClick")} />;
+};
+
+export const butonWithIcon = () => {
+  return (
+    <Button text="butonWithIcon" onClick={action("onClick")}>
+      <AiFillAccountBook />
+    </Button>
+  );
+};
+
+export const onlyIconButton = () => {
+  return (
+    <Button onClick={action("onClick")}>
+      <AiFillAccountBook />
+    </Button>
+  );
+};
+
+export default {
+  title: "Atoms/Button",
+  component: Button,
+};

--- a/src/common/Atoms/Button/index.tsx
+++ b/src/common/Atoms/Button/index.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import * as S from "./style";
+
+export interface ButtonProps {
+  children?: React.ReactNode;
+  curryingArgs?: string;
+  text?: string;
+  onClick?: () => void;
+  onClickCurrying?: (type: string) => () => void;
+}
+
+const Button: React.FC<ButtonProps> = ({ children, text, curryingArgs, onClick, onClickCurrying }) => {
+  return (
+    <>
+      <S.Button
+        data-testid={curryingArgs}
+        onClick={curryingArgs && onClickCurrying ? onClickCurrying(curryingArgs) : onClick}
+      >
+        {children}
+        {text}
+      </S.Button>
+    </>
+  );
+};
+
+export default Button;

--- a/src/common/Atoms/Button/style.ts
+++ b/src/common/Atoms/Button/style.ts
@@ -1,0 +1,3 @@
+import styled from "styled-components";
+
+export const Button = styled.button``;

--- a/src/common/Atoms/HashTag/hashTag.stories.tsx
+++ b/src/common/Atoms/HashTag/hashTag.stories.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { action } from "@storybook/addon-actions";
+import HashTag from "./index";
+
+export const hashtag = () => {
+  return <HashTag text="hashtag" onClick={action("onClick")} />;
+};
+
+export default {
+  title: "Atoms/HashTag",
+  component: HashTag,
+};

--- a/src/common/Atoms/HashTag/index.tsx
+++ b/src/common/Atoms/HashTag/index.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import * as S from "./style";
+
+export interface HashTagProps {
+  text: string;
+  onClick: () => void;
+}
+
+const HashTag: React.FC<HashTagProps> = ({ text, onClick }) => {
+  return (
+    <>
+      <S.HashTag onClick={onClick}>
+        <span>#</span>
+        <span>{text}</span>
+      </S.HashTag>
+    </>
+  );
+};
+
+export default HashTag;

--- a/src/common/Atoms/HashTag/style.ts
+++ b/src/common/Atoms/HashTag/style.ts
@@ -1,0 +1,3 @@
+import styled from "styled-components";
+
+export const HashTag = styled.li``;

--- a/src/common/Atoms/Input/index.tsx
+++ b/src/common/Atoms/Input/index.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import * as S from "./style";
+
+type inputType = "text" | "email" | "password";
+
+export interface InputProps {
+  disabled?: boolean;
+  //   isEntered?: boolean;
+  maxLength?: number;
+  placeholder?: string;
+  type?: inputType;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+const Input: React.FC<InputProps> = ({ disabled = false, maxLength = 20, placeholder, type, value, onChange }) => {
+  return (
+    <>
+      <S.Input
+        disabled={disabled}
+        placeholder={placeholder}
+        type={type}
+        maxLength={maxLength}
+        value={value}
+        onChange={onChange}
+      />
+    </>
+  );
+};
+
+export default Input;

--- a/src/common/Atoms/Input/input.stories.tsx
+++ b/src/common/Atoms/Input/input.stories.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { action } from "@storybook/addon-actions";
+import Input from "./index";
+
+export const emptyInput = () => {
+  return <Input value="" onChange={action("onChange")} />;
+};
+
+export const inputWithText = () => {
+  return <Input value="inputWithText" onChange={action("onChange")} />;
+};
+
+export const disabledInput = () => {
+  return <Input value="" onChange={action("onChange")} disabled />;
+};
+
+export default {
+  title: "Atoms/Input",
+  component: Input,
+};

--- a/src/common/Atoms/Input/style.ts
+++ b/src/common/Atoms/Input/style.ts
@@ -1,0 +1,3 @@
+import styled from "styled-components";
+
+export const Input = styled.input``;


### PR DESCRIPTION
## 관련 이슈

- #32 

## 변경 사항

- 버튼, 인풋, 해시태그 atoms 추가
- storybook.tsx 추가
- 추후 디자인이 나오면, 해당 파일들 디자인 적용 필요

## PR Point

- 리뷰어가 중점적으로 확인이 필요한 부분을 작성합니다.

## 참고 사항

- 그 외에 참고가 필요한 부분을 작성합니다.

## Check Point

- [ ] 빌드를 직접해서 올려보셨나요?
- [ ] 사용하지 않는 변수, import, 함수 등은 없나요?
- [ ] 테스트는 작성하셨나요?
- [ ] 테스트를 돌려보셨나요?
